### PR TITLE
Consider Redash parameters as string types instead of parens

### DIFF
--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -67,6 +67,7 @@ export default class Tokenizer {
     // 3. double quoted string using "" or \" to escape
     // 4. single quoted string using '' or \' to escape
     // 5. national character quoted string using N'' or N\' to escape
+    // 6. redash parameters
     createStringPattern(stringTypes) {
         const patterns = {
             "``": "((`[^`]*($|`))+)",
@@ -74,6 +75,7 @@ export default class Tokenizer {
             "\"\"": "((\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*(\"|$))+)",
             "''": "(('[^'\\\\]*(?:\\\\.[^'\\\\]*)*('|$))+)",
             "N''": "((N'[^N'\\\\]*(?:\\\\.[^N'\\\\]*)*('|$))+)",
+            "{{}}": "(\{\{(.*?)\}\})",
         };
 
         return stringTypes.map(t => patterns[t]).join("|");

--- a/src/languages/StandardSqlFormatter.js
+++ b/src/languages/StandardSqlFormatter.js
@@ -93,9 +93,9 @@ export default class StandardSqlFormatter {
                 reservedWords,
                 reservedToplevelWords,
                 reservedNewlineWords,
-                stringTypes: [`""`, "N''", "''", "``", "[]"],
-                openParens: ["(", "{", "CASE"],
-                closeParens: [")", "}", "END"],
+                stringTypes: [`""`, "N''", "''", "``", "[]", "{{}}"],
+                openParens: ["(", "CASE"],
+                closeParens: [")", "END"],
                 indexedPlaceholderTypes: ["?"],
                 namedPlaceholderTypes: ["@", ":"],
                 lineCommentTypes: ["#", "--"]


### PR DESCRIPTION
Small change to consider the parameters as Strings. This should cover two things:
1. Avoid a different styling on using the Add Parameter Dialog (this one adds whitespaces that are removed by formatting);
2. Avoid problems as this won't format anything inside `{{}}`.