### PR TITLE
Add CLRF support for line comment tokenizer

### DIFF
--- a/lib/core/Tokenizer.js
+++ b/lib/core/Tokenizer.js
@@ -60,7 +60,7 @@ var Tokenizer = function () {
     Tokenizer.prototype.createLineCommentRegex = function createLineCommentRegex(lineCommentTypes) {
         return new RegExp("^((?:" + lineCommentTypes.map(function (c) {
             return (0, _escapeRegExp2["default"])(c);
-        }).join("|") + ").*?(?:\n|$))");
+        }).join("|") + ").*?(?:\n|\r\n|$))");
     };
 
     Tokenizer.prototype.createReservedWordRegex = function createReservedWordRegex(reservedWords) {

--- a/src/core/Tokenizer.js
+++ b/src/core/Tokenizer.js
@@ -43,7 +43,7 @@ export default class Tokenizer {
     }
 
     createLineCommentRegex(lineCommentTypes) {
-        return new RegExp(`^((?:${lineCommentTypes.map(c => escapeRegExp(c)).join("|")}).*?(?:\n|$))`);
+        return new RegExp(`^((?:${lineCommentTypes.map(c => escapeRegExp(c)).join("|")}).*?(?:\n|\r\n|$))`);
     }
 
     createReservedWordRegex(reservedWords) {

--- a/test/StandardSqlFormatterTest.js
+++ b/test/StandardSqlFormatterTest.js
@@ -399,4 +399,16 @@ describe("StandardSqlFormatter", function() {
     it("not formats dollar sign token", function() {
         expect(sqlFormatter.format("$a.b.c")).toBe("$a.b.c");
     });
+
+    it("formats comments with CLRF correctly", function() {
+        const queryText = 'select \r\nsession_id,\r\n   -- provider_program_id,\r\n   -- publisher_id from conversion_fact';
+        const expectedFormattedQueryText = [
+            'select',
+            '  session_id,',
+            '  -- provider_program_id,',
+            '  -- publisher_id from conversion_fact',
+        ].join('\n');
+        expect(sqlFormatter.format(queryText)).toBe(expectedFormattedQueryText);
+    });
+
 });


### PR DESCRIPTION
The formatter we are using does not support CLRF (\r\n) for its line-comment regex in its tokenizer. This is causing issues in Windows where comments (--) are getting tokenized as individual operators.